### PR TITLE
Fixes for OpenVR 0.9.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ipch
 .vs
 *.opensdf
 *.opendb
+*.VC.db

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. Install SteamVR.  It is under "Tools" in everyone's Steam Library.  steam://install/250820
 2. Install "Sixense SDK for the Razer Hydra".  It is also under "Tools".  steam://install/42300
-3. Fetch the OpenVR SDK 0.9.15 from https://github.com/ValveSoftware/openvr .  That version SHA is c95571027b79644643bca044538144c96194c4f2.  Newer version should also work with minor changes.
+3. Fetch the OpenVR SDK 0.9.19 from https://github.com/ValveSoftware/openvr .  That version SHA is f1ffbf4e92f383bdb453d58f9583c51a5ec350d9.  Newer version should also work with minor changes.
 
 The solution and project files are for Visual Studio 2015.
 

--- a/drivers/driver_hydra/driver_hydra.cpp
+++ b/drivers/driver_hydra/driver_hydra.cpp
@@ -487,6 +487,11 @@ void CHydraHmdLatest::Deactivate()
 	m_unSteamVRTrackedDeviceId = vr::k_unTrackedDeviceIndexInvalid;
 }
 
+void CHydraHmdLatest::PowerOff()
+{
+	// TODO
+}
+
 void CHydraHmdLatest::DebugRequest( const char * pchRequest, char * pchResponseBuffer, uint32_t unResponseBufferSize )
 {
 	std::istringstream ss( pchRequest );

--- a/drivers/driver_hydra/driver_hydra.h
+++ b/drivers/driver_hydra/driver_hydra.h
@@ -82,6 +82,7 @@ public:
 	// Implementation of vr::ITrackedDeviceServerDriver
 	virtual vr::EVRInitError Activate( uint32_t unObjectId ) override;
 	virtual void Deactivate() override;
+	virtual void PowerOff() override;
 	void *GetComponent( const char *pchComponentNameAndVersion ) override;
 	virtual void DebugRequest( const char * pchRequest, char * pchResponseBuffer, uint32_t unResponseBufferSize ) override;
 	virtual vr::DriverPose_t GetPose() override;


### PR DESCRIPTION
- Adds empty PowerOff implementation. 
- Updates documentation for building with the latest OpenVR release 0.9.19.
